### PR TITLE
Allow our host through the ActionDispatch::HostAuthorization middleware

### DIFF
--- a/files/src/api/config/initializers/host_authorization.rb
+++ b/files/src/api/config/initializers/host_authorization.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Whitelist our hostname in ActionDispatch::HostAuthorization
+  config.hosts << 'obs-reviewlab.opensuse.org'
+end


### PR DESCRIPTION
https://blog.saeloun.com/2019/10/31/rails-6-adds-guard-against-dns-rebinding-attacks.html