### PR TITLE
Enable public file server by default

### DIFF
--- a/files/src/api/config/initializers/public_files.rb
+++ b/files/src/api/config/initializers/public_files.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  # Enable Rails's static asset server (we don't run Apache or nginx here)
+  config.public_file_server.enabled = true
+end


### PR DESCRIPTION
We don't run any web server in front, we should serve things directly.