### PR TITLE
Update the external network syntax in docker-compose files

### DIFF
--- a/files/docker-compose.yml
+++ b/files/docker-compose.yml
@@ -42,5 +42,5 @@ services:
     - worker
 networks:
   traefik:
-    external:
-      name: traefik_default
+    name: traefik_default
+    external: true


### PR DESCRIPTION
This caused some issues with the newer versions of docker, let's update it